### PR TITLE
incorrect handling of the situation when the current month is less th…

### DIFF
--- a/moment/date.py
+++ b/moment/date.py
@@ -22,6 +22,8 @@ def add_month(date, number):
 def subtract_month(date, number):
     """Subtract a number of months from a date."""
     month = date.month - 1 - number
+    if month < 0:
+        month -= 12
     return update_month(date, month)
 
 

--- a/tests.py
+++ b/tests.py
@@ -210,5 +210,27 @@ class Weekdays(TestCase):
         self.assertEqual(d.replace(weekday=24).date, expecting)
 
 
+class SubtractMonth(TestCase):
+
+    def test_subtract_twelve_month_from_last_month(self):
+        d = moment.date((2012, 12, 1))
+        expecting = moment.date((2011, 12, 1)).date
+        self.assertEqual(d.subtract(months=12).date, expecting)
+
+    def test_subtract_one_month_from_first_month(self):
+        d = moment.date((2012, 1, 1))
+        expecting = moment.date((2011, 12, 1)).date
+        self.assertEqual(d.subtract(months=1).date, expecting)
+
+    def test_subtract_less_then_cur_month(self):
+        d = moment.date((2012, 3, 1))
+        expecting = moment.date((2011, 9, 1)).date
+        self.assertEqual(d.subtract(months=6).date, expecting)
+
+    def test_subtract_zero_months(self):
+        d = moment.date((2012, 3, 1))
+        expecting = moment.date((2012, 3, 1)).date
+        self.assertEqual(d.subtract(months=0).date, expecting)
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
…an what needs to be deducted (for example 15.03.2018 - 6 months = 15.09.2018), + tests